### PR TITLE
Added script to generate csv and png files with daily commit count of existing Exercism repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.csv
+*__pycache__*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.csv
 *__pycache__*
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.csv
 *__pycache__*
 .env
+results/

--- a/scripts/commit_count/.env.example
+++ b/scripts/commit_count/.env.example
@@ -1,0 +1,2 @@
+RESULT_DIR="/full/path/to/the/commit/count/result/dir"
+GITHUB_TOKEN="Acces token acquired from Github"

--- a/scripts/commit_count/Pipfile
+++ b/scripts/commit_count/Pipfile
@@ -4,9 +4,10 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pygithub = "*"
 pip = "==18.0"
 python-dateutil = "*"
+aiohttp = "*"
+aiofiles = "*"
 
 [dev-packages]
 

--- a/scripts/commit_count/Pipfile
+++ b/scripts/commit_count/Pipfile
@@ -12,6 +12,3 @@ matplotlib = "*"
 pandas = "*"
 
 [dev-packages]
-
-[requires]
-python_version = "3.6"

--- a/scripts/commit_count/Pipfile
+++ b/scripts/commit_count/Pipfile
@@ -8,6 +8,8 @@ pip = "==18.0"
 python-dateutil = "*"
 aiohttp = "*"
 aiofiles = "*"
+matplotlib = "*"
+pandas = "*"
 
 [dev-packages]
 

--- a/scripts/commit_count/Pipfile
+++ b/scripts/commit_count/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pygithub = "*"
+pip = "==18.0"
+python-dateutil = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.6"

--- a/scripts/commit_count/Pipfile.lock
+++ b/scripts/commit_count/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8a278dde1dd6d9532e023d352a352e17d42993cd0f1f3fab2cfd0f81a0d3d2fc"
+            "sha256": "351db5c3cf17a4edfbf74ebcd26a361b829f0e31062fd89428ce7ed7b25df340"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -73,6 +73,13 @@
             ],
             "version": "==3.0.4"
         },
+        "cycler": {
+            "hashes": [
+                "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d",
+                "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"
+            ],
+            "version": "==0.10.0"
+        },
         "idna": {
             "hashes": [
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
@@ -86,6 +93,58 @@
             ],
             "markers": "python_version < '3.7'",
             "version": "==1.1.0"
+        },
+        "kiwisolver": {
+            "hashes": [
+                "sha256:0ee4ed8b3ae8f5f712b0aa9ebd2858b5b232f1b9a96b0943dceb34df2a223bc3",
+                "sha256:0f7f532f3c94e99545a29f4c3f05637f4d2713e7fd91b4dd8abfc18340b86cd5",
+                "sha256:1a078f5dd7e99317098f0e0d490257fd0349d79363e8c923d5bb76428f318421",
+                "sha256:1aa0b55a0eb1bd3fa82e704f44fb8f16e26702af1a073cc5030eea399e617b56",
+                "sha256:2874060b91e131ceeff00574b7c2140749c9355817a4ed498e82a4ffa308ecbc",
+                "sha256:379d97783ba8d2934d52221c833407f20ca287b36d949b4bba6c75274bcf6363",
+                "sha256:3b791ddf2aefc56382aadc26ea5b352e86a2921e4e85c31c1f770f527eb06ce4",
+                "sha256:4329008a167fac233e398e8a600d1b91539dc33c5a3eadee84c0d4b04d4494fa",
+                "sha256:45813e0873bbb679334a161b28cb9606d9665e70561fd6caa8863e279b5e464b",
+                "sha256:53a5b27e6b5717bdc0125338a822605084054c80f382051fb945d2c0e6899a20",
+                "sha256:574f24b9805cb1c72d02b9f7749aa0cc0b81aa82571be5201aa1453190390ae5",
+                "sha256:66f82819ff47fa67a11540da96966fb9245504b7f496034f534b81cacf333861",
+                "sha256:79e5fe3ccd5144ae80777e12973027bd2f4f5e3ae8eb286cabe787bed9780138",
+                "sha256:83410258eb886f3456714eea4d4304db3a1fc8624623fc3f38a487ab36c0f653",
+                "sha256:8b6a7b596ce1d2a6d93c3562f1178ebd3b7bb445b3b0dd33b09f9255e312a965",
+                "sha256:9576cb63897fbfa69df60f994082c3f4b8e6adb49cccb60efb2a80a208e6f996",
+                "sha256:95a25d9f3449046ecbe9065be8f8380c03c56081bc5d41fe0fb964aaa30b2195",
+                "sha256:a424f048bebc4476620e77f3e4d1f282920cef9bc376ba16d0b8fe97eec87cde",
+                "sha256:aaec1cfd94f4f3e9a25e144d5b0ed1eb8a9596ec36d7318a504d813412563a85",
+                "sha256:acb673eecbae089ea3be3dcf75bfe45fc8d4dcdc951e27d8691887963cf421c7",
+                "sha256:b15bc8d2c2848a4a7c04f76c9b3dc3561e95d4dabc6b4f24bfabe5fd81a0b14f",
+                "sha256:b1c240d565e977d80c0083404c01e4d59c5772c977fae2c483f100567f50847b",
+                "sha256:c595693de998461bcd49b8d20568c8870b3209b8ea323b2a7b0ea86d85864694",
+                "sha256:ce3be5d520b4d2c3e5eeb4cd2ef62b9b9ab8ac6b6fedbaa0e39cdb6f50644278",
+                "sha256:e0f910f84b35c36a3513b96d816e6442ae138862257ae18a0019d2fc67b041dc",
+                "sha256:ea36e19ac0a483eea239320aef0bd40702404ff8c7e42179a2d9d36c5afcb55c",
+                "sha256:efabbcd4f406b532206b8801058c8bab9e79645b9880329253ae3322b7b02cd5",
+                "sha256:f923406e6b32c86309261b8195e24e18b6a8801df0cfc7814ac44017bfcb3939"
+            ],
+            "version": "==1.0.1"
+        },
+        "matplotlib": {
+            "hashes": [
+                "sha256:16aa61846efddf91df623bbb4598e63be1068a6b6a2e6361cc802b41c7a286eb",
+                "sha256:1975b71a33ac986bb39b6d5cfbc15c7b1f218f1134efb4eb3881839d6ae69984",
+                "sha256:2b222744bd54781e6cc0b717fa35a54e5f176ba2ced337f27c5b435b334ef854",
+                "sha256:317643c0e88fad55414347216362b2e229c130edd5655fea5f8159a803098468",
+                "sha256:4269ce3d1b897d46fc3cc2273a0cc2a730345bb47e4456af662e6fca85c89dd7",
+                "sha256:65214fd668975077cdf8d408ccf2b2d6bdf73b4e6895a79f8e99ce4f0b43fcdb",
+                "sha256:74bc213ab8a92d86a0b304d9359d1e1d14168d4c6121b83862c9d8a88b89a738",
+                "sha256:88949be0db54755995dfb0210d0099a8712a3c696c860441971354c3debfc4af",
+                "sha256:8e1223d868be89423ec95ada5f37aa408ee64fe76ccb8e4d5f533699ba4c0e4a",
+                "sha256:9fa00f2d7a552a95fa6016e498fdeb6d74df537853dda79a9055c53dfc8b6e1a",
+                "sha256:c27fd46cab905097ba4bc28d5ba5289930f313fb1970c9d41092c9975b80e9b4",
+                "sha256:c94b792af431f6adb6859eb218137acd9a35f4f7442cea57e4a59c54751c36af",
+                "sha256:f4c12a01eb2dc16693887a874ba948b18c92f425c4d329639ece6d3bb8e631bb"
+            ],
+            "index": "pypi",
+            "version": "==3.0.2"
         },
         "multidict": {
             "hashes": [
@@ -121,6 +180,72 @@
             ],
             "version": "==4.5.2"
         },
+        "numpy": {
+            "hashes": [
+                "sha256:0df89ca13c25eaa1621a3f09af4c8ba20da849692dcae184cb55e80952c453fb",
+                "sha256:154c35f195fd3e1fad2569930ca51907057ae35e03938f89a8aedae91dd1b7c7",
+                "sha256:18e84323cdb8de3325e741a7a8dd4a82db74fde363dce32b625324c7b32aa6d7",
+                "sha256:1e8956c37fc138d65ded2d96ab3949bd49038cc6e8a4494b1515b0ba88c91565",
+                "sha256:23557bdbca3ccbde3abaa12a6e82299bc92d2b9139011f8c16ca1bb8c75d1e95",
+                "sha256:24fd645a5e5d224aa6e39d93e4a722fafa9160154f296fd5ef9580191c755053",
+                "sha256:36e36b6868e4440760d4b9b44587ea1dc1f06532858d10abba98e851e154ca70",
+                "sha256:3d734559db35aa3697dadcea492a423118c5c55d176da2f3be9c98d4803fc2a7",
+                "sha256:416a2070acf3a2b5d586f9a6507bb97e33574df5bd7508ea970bbf4fc563fa52",
+                "sha256:4a22dc3f5221a644dfe4a63bf990052cc674ef12a157b1056969079985c92816",
+                "sha256:4d8d3e5aa6087490912c14a3c10fbdd380b40b421c13920ff468163bc50e016f",
+                "sha256:4f41fd159fba1245e1958a99d349df49c616b133636e0cf668f169bce2aeac2d",
+                "sha256:561ef098c50f91fbac2cc9305b68c915e9eb915a74d9038ecf8af274d748f76f",
+                "sha256:56994e14b386b5c0a9b875a76d22d707b315fa037affc7819cda08b6d0489756",
+                "sha256:73a1f2a529604c50c262179fcca59c87a05ff4614fe8a15c186934d84d09d9a5",
+                "sha256:7da99445fd890206bfcc7419f79871ba8e73d9d9e6b82fe09980bc5bb4efc35f",
+                "sha256:99d59e0bcadac4aa3280616591fb7bcd560e2218f5e31d5223a2e12a1425d495",
+                "sha256:a4cc09489843c70b22e8373ca3dfa52b3fab778b57cf81462f1203b0852e95e3",
+                "sha256:a61dc29cfca9831a03442a21d4b5fd77e3067beca4b5f81f1a89a04a71cf93fa",
+                "sha256:b1853df739b32fa913cc59ad9137caa9cc3d97ff871e2bbd89c2a2a1d4a69451",
+                "sha256:b1f44c335532c0581b77491b7715a871d0dd72e97487ac0f57337ccf3ab3469b",
+                "sha256:b261e0cb0d6faa8fd6863af26d30351fd2ffdb15b82e51e81e96b9e9e2e7ba16",
+                "sha256:c857ae5dba375ea26a6228f98c195fec0898a0fd91bcf0e8a0cae6d9faf3eca7",
+                "sha256:cf5bb4a7d53a71bb6a0144d31df784a973b36d8687d615ef6a7e9b1809917a9b",
+                "sha256:db9814ff0457b46f2e1d494c1efa4111ca089e08c8b983635ebffb9c1573361f",
+                "sha256:df04f4bad8a359daa2ff74f8108ea051670cafbca533bb2636c58b16e962989e",
+                "sha256:ecf81720934a0e18526177e645cbd6a8a21bb0ddc887ff9738de07a1df5c6b61",
+                "sha256:edfa6fba9157e0e3be0f40168eb142511012683ac3dc82420bee4a3f3981b30e"
+            ],
+            "version": "==1.15.4"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:11975fad9edbdb55f1a560d96f91830e83e29bed6ad5ebf506abda09818eaf60",
+                "sha256:12e13d127ca1b585dd6f6840d3fe3fa6e46c36a6afe2dbc5cb0b57032c902e31",
+                "sha256:1c87fcb201e1e06f66e23a61a5fea9eeebfe7204a66d99df24600e3f05168051",
+                "sha256:242e9900de758e137304ad4b5663c2eff0d798c2c3b891250bd0bd97144579da",
+                "sha256:26c903d0ae1542890cb9abadb4adcb18f356b14c2df46e4ff657ae640e3ac9e7",
+                "sha256:2e1e88f9d3e5f107b65b59cd29f141995597b035d17cc5537e58142038942e1a",
+                "sha256:31b7a48b344c14691a8e92765d4023f88902ba3e96e2e4d0364d3453cdfd50db",
+                "sha256:4fd07a932b4352f8a8973761ab4e84f965bf81cc750fb38e04f01088ab901cb8",
+                "sha256:5b24ca47acf69222e82530e89111dd9d14f9b970ab2cd3a1c2c78f0c4fbba4f4",
+                "sha256:647b3b916cc8f6aeba240c8171be3ab799c3c1b2ea179a3be0bd2712c4237553",
+                "sha256:66b060946046ca27c0e03e9bec9bba3e0b918bafff84c425ca2cc2e157ce121e",
+                "sha256:6efa9fa6e1434141df8872d0fa4226fc301b17aacf37429193f9d70b426ea28f",
+                "sha256:be4715c9d8367e51dbe6bc6d05e205b1ae234f0dc5465931014aa1c4af44c1ba",
+                "sha256:bea90da782d8e945fccfc958585210d23de374fa9294a9481ed2abcef637ebfc",
+                "sha256:d318d77ab96f66a59e792a481e2701fba879e1a453aefeebdb17444fe204d1ed",
+                "sha256:d785fc08d6f4207437e900ffead930a61e634c5e4f980ba6d3dc03c9581748c7",
+                "sha256:de9559287c4fe8da56e8c3878d2374abc19d1ba2b807bfa7553e912a8e5ba87c",
+                "sha256:f4f98b190bb918ac0bc0e3dd2ab74ff3573da9f43106f6dba6385406912ec00f",
+                "sha256:f71f1a7e2d03758f6e957896ed696254e2bc83110ddbc6942018f1a232dd9dad",
+                "sha256:fb944c8f0b0ab5c1f7846c686bc4cdf8cde7224655c12edcd59d5212cd57bec0"
+            ],
+            "index": "pypi",
+            "version": "==0.23.4"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:40856e74d4987de5d01761a22d1621ae1c7f8774585acae358aa5c5936c6c90b",
+                "sha256:f353aab21fd474459d97b709e527b5571314ee5f067441dc9f88e33eecd96592"
+            ],
+            "version": "==2.3.0"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
@@ -128,6 +253,13 @@
             ],
             "index": "pypi",
             "version": "==2.7.5"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
+                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
+            ],
+            "version": "==2018.7"
         },
         "six": {
             "hashes": [

--- a/scripts/commit_count/Pipfile.lock
+++ b/scripts/commit_count/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "31bd621c969b5d9c5352c727b2a79d0a77af875e2050816d07a362f98c271254"
+            "sha256": "8a278dde1dd6d9532e023d352a352e17d42993cd0f1f3fab2cfd0f81a0d3d2fc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,12 +16,55 @@
         ]
     },
     "default": {
-        "certifi": {
+        "aiofiles": {
             "hashes": [
-                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
-                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
+                "sha256:021ea0ba314a86027c166ecc4b4c07f2d40fc0f4b3a950d1868a0f2571c2bbee",
+                "sha256:1e644c2573f953664368de28d2aa4c89dfd64550429d0c27c4680ccd3aa4985d"
             ],
-            "version": "==2018.10.15"
+            "index": "pypi",
+            "version": "==0.4.0"
+        },
+        "aiohttp": {
+            "hashes": [
+                "sha256:0419705a36b43c0ac6f15469f9c2a08cad5c939d78bd12a5c23ea167c8253b2b",
+                "sha256:1812fc4bc6ac1bde007daa05d2d0f61199324e0cc893b11523e646595047ca08",
+                "sha256:2214b5c0153f45256d5d52d1e0cafe53f9905ed035a142191727a5fb620c03dd",
+                "sha256:275909137f0c92c61ba6bb1af856a522d5546f1de8ea01e4e726321c697754ac",
+                "sha256:3983611922b561868428ea1e7269e757803713f55b53502423decc509fef1650",
+                "sha256:51afec6ffa50a9da4cdef188971a802beb1ca8e8edb40fa429e5e529db3475fa",
+                "sha256:589f2ec8a101a0f340453ee6945bdfea8e1cd84c8d88e5be08716c34c0799d95",
+                "sha256:789820ddc65e1f5e71516adaca2e9022498fa5a837c79ba9c692a9f8f916c330",
+                "sha256:7a968a0bdaaf9abacc260911775611c9a602214a23aeb846f2eb2eeaa350c4dc",
+                "sha256:7aeefbed253f59ea39e70c5848de42ed85cb941165357fc7e87ab5d8f1f9592b",
+                "sha256:7b2eb55c66512405103485bd7d285a839d53e7fdc261ab20e5bcc51d7aaff5de",
+                "sha256:87bc95d3d333bb689c8d755b4a9d7095a2356108002149523dfc8e607d5d32a4",
+                "sha256:9d80e40db208e29168d3723d1440ecbb06054d349c5ece6a2c5a611490830dd7",
+                "sha256:a1b442195c2a77d33e4dbee67c9877ccbdd3a1f686f91eb479a9577ed8cc326b",
+                "sha256:ab3d769413b322d6092f169f316f7b21cd261a7589f7e31db779d5731b0480d8",
+                "sha256:b066d3dec5d0f5aee6e34e5765095dc3d6d78ef9839640141a2b20816a0642bd",
+                "sha256:b24e7845ae8de3e388ef4bcfcf7f96b05f52c8e633b33cf8003a6b1d726fc7c2",
+                "sha256:c59a953c3f8524a7c86eaeaef5bf702555be12f5668f6384149fe4bb75c52698",
+                "sha256:cf2cc6c2c10d242790412bea7ccf73726a9a44b4c4b073d2699ef3b48971fd95",
+                "sha256:e0c9c8d4150ae904f308ff27b35446990d2b1dfc944702a21925937e937394c6",
+                "sha256:f1839db4c2b08a9c8f9788112644f8a8557e8e0ecc77b07091afabb941dc55d0",
+                "sha256:f3df52362be39908f9c028a65490fae0475e4898b43a03d8aa29d1e765b45e07"
+            ],
+            "index": "pypi",
+            "version": "==3.4.4"
+        },
+        "async-timeout": {
+            "hashes": [
+                "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f",
+                "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"
+            ],
+            "version": "==3.0.1"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+            ],
+            "version": "==18.2.0"
         },
         "chardet": {
             "hashes": [
@@ -30,33 +73,53 @@
             ],
             "version": "==3.0.4"
         },
-        "deprecated": {
-            "hashes": [
-                "sha256:0b1e043af3bab6c7ebcf96a471d0e75685ffe1390924e28137a8f1bd33781195",
-                "sha256:bcad09662cbf6f1a01fcb72474b9ab4bd35ee284b5f064bc31c4524d2f4cd82e"
-            ],
-            "version": "==1.2.3"
-        },
         "idna": {
             "hashes": [
-                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
-                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
-            "version": "==2.7"
+            "version": "==2.8"
         },
-        "pygithub": {
+        "idna-ssl": {
             "hashes": [
-                "sha256:af205fa50d5e18b880c567f77cffbafa23f69988ca8f8f869ad30c535bc7d36f"
+                "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"
             ],
-            "index": "pypi",
-            "version": "==1.43.2"
+            "markers": "python_version < '3.7'",
+            "version": "==1.1.0"
         },
-        "pyjwt": {
+        "multidict": {
             "hashes": [
-                "sha256:30b1380ff43b55441283cc2b2676b755cca45693ae3097325dea01f3d110628c",
-                "sha256:4ee413b357d53fd3fb44704577afac88e72e878716116270d722723d65b42176"
+                "sha256:024b8129695a952ebd93373e45b5d341dbb87c17ce49637b34000093f243dd4f",
+                "sha256:041e9442b11409be5e4fc8b6a97e4bcead758ab1e11768d1e69160bdde18acc3",
+                "sha256:045b4dd0e5f6121e6f314d81759abd2c257db4634260abcfe0d3f7083c4908ef",
+                "sha256:047c0a04e382ef8bd74b0de01407e8d8632d7d1b4db6f2561106af812a68741b",
+                "sha256:068167c2d7bbeebd359665ac4fff756be5ffac9cda02375b5c5a7c4777038e73",
+                "sha256:148ff60e0fffa2f5fad2eb25aae7bef23d8f3b8bdaf947a65cdbe84a978092bc",
+                "sha256:1d1c77013a259971a72ddaa83b9f42c80a93ff12df6a4723be99d858fa30bee3",
+                "sha256:1d48bc124a6b7a55006d97917f695effa9725d05abe8ee78fd60d6588b8344cd",
+                "sha256:31dfa2fc323097f8ad7acd41aa38d7c614dd1960ac6681745b6da124093dc351",
+                "sha256:34f82db7f80c49f38b032c5abb605c458bac997a6c3142e0d6c130be6fb2b941",
+                "sha256:3d5dd8e5998fb4ace04789d1d008e2bb532de501218519d70bb672c4c5a2fc5d",
+                "sha256:4a6ae52bd3ee41ee0f3acf4c60ceb3f44e0e3bc52ab7da1c2b2aa6703363a3d1",
+                "sha256:4b02a3b2a2f01d0490dd39321c74273fed0568568ea0e7ea23e02bd1fb10a10b",
+                "sha256:4b843f8e1dd6a3195679d9838eb4670222e8b8d01bc36c9894d6c3538316fa0a",
+                "sha256:5de53a28f40ef3c4fd57aeab6b590c2c663de87a5af76136ced519923d3efbb3",
+                "sha256:61b2b33ede821b94fa99ce0b09c9ece049c7067a33b279f343adfe35108a4ea7",
+                "sha256:6a3a9b0f45fd75dc05d8e93dc21b18fc1670135ec9544d1ad4acbcf6b86781d0",
+                "sha256:76ad8e4c69dadbb31bad17c16baee61c0d1a4a73bed2590b741b2e1a46d3edd0",
+                "sha256:7ba19b777dc00194d1b473180d4ca89a054dd18de27d0ee2e42a103ec9b7d014",
+                "sha256:7c1b7eab7a49aa96f3db1f716f0113a8a2e93c7375dd3d5d21c4941f1405c9c5",
+                "sha256:7fc0eee3046041387cbace9314926aa48b681202f8897f8bff3809967a049036",
+                "sha256:8ccd1c5fff1aa1427100ce188557fc31f1e0a383ad8ec42c559aabd4ff08802d",
+                "sha256:8e08dd76de80539d613654915a2f5196dbccc67448df291e69a88712ea21e24a",
+                "sha256:c18498c50c59263841862ea0501da9f2b3659c00db54abfbf823a80787fde8ce",
+                "sha256:c49db89d602c24928e68c0d510f4fcf8989d77defd01c973d6cbe27e684833b1",
+                "sha256:ce20044d0317649ddbb4e54dab3c1bcc7483c78c27d3f58ab3d0c7e6bc60d26a",
+                "sha256:d1071414dd06ca2eafa90c85a079169bfeb0e5f57fd0b45d44c092546fcd6fd9",
+                "sha256:d3be11ac43ab1a3e979dac80843b42226d5d3cccd3986f2e03152720a4297cd7",
+                "sha256:db603a1c235d110c860d5f39988ebc8218ee028f07a7cbc056ba6424372ca31b"
             ],
-            "version": "==1.6.4"
+            "version": "==4.5.2"
         },
         "python-dateutil": {
             "hashes": [
@@ -66,33 +129,28 @@
             "index": "pypi",
             "version": "==2.7.5"
         },
-        "requests": {
-            "hashes": [
-                "sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c",
-                "sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279"
-            ],
-            "version": "==2.20.0"
-        },
         "six": {
             "hashes": [
-                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
-                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "version": "==1.11.0"
+            "version": "==1.12.0"
         },
-        "urllib3": {
+        "yarl": {
             "hashes": [
-                "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
-                "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
+                "sha256:024ecdc12bc02b321bc66b41327f930d1c2c543fa9a561b39861da9388ba7aa9",
+                "sha256:2f3010703295fbe1aec51023740871e64bb9664c789cba5a6bdf404e93f7568f",
+                "sha256:3890ab952d508523ef4881457c4099056546593fa05e93da84c7250516e632eb",
+                "sha256:3e2724eb9af5dc41648e5bb304fcf4891adc33258c6e14e2a7414ea32541e320",
+                "sha256:5badb97dd0abf26623a9982cd448ff12cb39b8e4c94032ccdedf22ce01a64842",
+                "sha256:73f447d11b530d860ca1e6b582f947688286ad16ca42256413083d13f260b7a0",
+                "sha256:7ab825726f2940c16d92aaec7d204cfc34ac26c0040da727cf8ba87255a33829",
+                "sha256:b25de84a8c20540531526dfbb0e2d2b648c13fd5dd126728c496d7c3fea33310",
+                "sha256:c6e341f5a6562af74ba55205dbd56d248daf1b5748ec48a0200ba227bb9e33f4",
+                "sha256:c9bb7c249c4432cd47e75af3864bc02d26c9594f49c82e2a28624417f0ae63b8",
+                "sha256:e060906c0c585565c718d1c3841747b61c5439af2211e185f6739a9412dfbde1"
             ],
-            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version < '4' and python_version != '3.0.*'",
-            "version": "==1.24"
-        },
-        "wrapt": {
-            "hashes": [
-                "sha256:d4d560d479f2c21e1b5443bbd15fe7ec4b37fe7e53d335d3b9b0a7b1226fe3c6"
-            ],
-            "version": "==1.10.11"
+            "version": "==1.3.0"
         }
     },
     "develop": {}

--- a/scripts/commit_count/Pipfile.lock
+++ b/scripts/commit_count/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "351db5c3cf17a4edfbf74ebcd26a361b829f0e31062fd89428ce7ed7b25df340"
+            "sha256": "2cea1ed1ba31728035eb6f8297d2cd01c8ee737fee4442ef231fd145d505891d"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.6"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",
@@ -26,31 +24,31 @@
         },
         "aiohttp": {
             "hashes": [
-                "sha256:0419705a36b43c0ac6f15469f9c2a08cad5c939d78bd12a5c23ea167c8253b2b",
-                "sha256:1812fc4bc6ac1bde007daa05d2d0f61199324e0cc893b11523e646595047ca08",
-                "sha256:2214b5c0153f45256d5d52d1e0cafe53f9905ed035a142191727a5fb620c03dd",
-                "sha256:275909137f0c92c61ba6bb1af856a522d5546f1de8ea01e4e726321c697754ac",
-                "sha256:3983611922b561868428ea1e7269e757803713f55b53502423decc509fef1650",
-                "sha256:51afec6ffa50a9da4cdef188971a802beb1ca8e8edb40fa429e5e529db3475fa",
-                "sha256:589f2ec8a101a0f340453ee6945bdfea8e1cd84c8d88e5be08716c34c0799d95",
-                "sha256:789820ddc65e1f5e71516adaca2e9022498fa5a837c79ba9c692a9f8f916c330",
-                "sha256:7a968a0bdaaf9abacc260911775611c9a602214a23aeb846f2eb2eeaa350c4dc",
-                "sha256:7aeefbed253f59ea39e70c5848de42ed85cb941165357fc7e87ab5d8f1f9592b",
-                "sha256:7b2eb55c66512405103485bd7d285a839d53e7fdc261ab20e5bcc51d7aaff5de",
-                "sha256:87bc95d3d333bb689c8d755b4a9d7095a2356108002149523dfc8e607d5d32a4",
-                "sha256:9d80e40db208e29168d3723d1440ecbb06054d349c5ece6a2c5a611490830dd7",
-                "sha256:a1b442195c2a77d33e4dbee67c9877ccbdd3a1f686f91eb479a9577ed8cc326b",
-                "sha256:ab3d769413b322d6092f169f316f7b21cd261a7589f7e31db779d5731b0480d8",
-                "sha256:b066d3dec5d0f5aee6e34e5765095dc3d6d78ef9839640141a2b20816a0642bd",
-                "sha256:b24e7845ae8de3e388ef4bcfcf7f96b05f52c8e633b33cf8003a6b1d726fc7c2",
-                "sha256:c59a953c3f8524a7c86eaeaef5bf702555be12f5668f6384149fe4bb75c52698",
-                "sha256:cf2cc6c2c10d242790412bea7ccf73726a9a44b4c4b073d2699ef3b48971fd95",
-                "sha256:e0c9c8d4150ae904f308ff27b35446990d2b1dfc944702a21925937e937394c6",
-                "sha256:f1839db4c2b08a9c8f9788112644f8a8557e8e0ecc77b07091afabb941dc55d0",
-                "sha256:f3df52362be39908f9c028a65490fae0475e4898b43a03d8aa29d1e765b45e07"
+                "sha256:00d198585474299c9c3b4f1d5de1a576cc230d562abc5e4a0e81d71a20a6ca55",
+                "sha256:0155af66de8c21b8dba4992aaeeabf55503caefae00067a3b1139f86d0ec50ed",
+                "sha256:09654a9eca62d1bd6d64aa44db2498f60a5c1e0ac4750953fdd79d5c88955e10",
+                "sha256:199f1d106e2b44b6dacdf6f9245493c7d716b01d0b7fbe1959318ba4dc64d1f5",
+                "sha256:296f30dedc9f4b9e7a301e5cc963012264112d78a1d3094cd83ef148fdf33ca1",
+                "sha256:368ed312550bd663ce84dc4b032a962fcb3c7cae099dbbd48663afc305e3b939",
+                "sha256:40d7ea570b88db017c51392349cf99b7aefaaddd19d2c78368aeb0bddde9d390",
+                "sha256:629102a193162e37102c50713e2e31dc9a2fe7ac5e481da83e5bb3c0cee700aa",
+                "sha256:6d5ec9b8948c3d957e75ea14d41e9330e1ac3fed24ec53766c780f82805140dc",
+                "sha256:87331d1d6810214085a50749160196391a712a13336cd02ce1c3ea3d05bcf8d5",
+                "sha256:9a02a04bbe581c8605ac423ba3a74999ec9d8bce7ae37977a3d38680f5780b6d",
+                "sha256:9c4c83f4fa1938377da32bc2d59379025ceeee8e24b89f72fcbccd8ca22dc9bf",
+                "sha256:9cddaff94c0135ee627213ac6ca6d05724bfe6e7a356e5e09ec57bd3249510f6",
+                "sha256:a25237abf327530d9561ef751eef9511ab56fd9431023ca6f4803f1994104d72",
+                "sha256:a5cbd7157b0e383738b8e29d6e556fde8726823dae0e348952a61742b21aeb12",
+                "sha256:a97a516e02b726e089cffcde2eea0d3258450389bbac48cbe89e0f0b6e7b0366",
+                "sha256:acc89b29b5f4e2332d65cd1b7d10c609a75b88ef8925d487a611ca788432dfa4",
+                "sha256:b05bd85cc99b06740aad3629c2585bda7b83bd86e080b44ba47faf905fdf1300",
+                "sha256:c2bec436a2b5dafe5eaeb297c03711074d46b6eb236d002c13c42f25c4a8ce9d",
+                "sha256:cc619d974c8c11fe84527e4b5e1c07238799a8c29ea1c1285149170524ba9303",
+                "sha256:d4392defd4648badaa42b3e101080ae3313e8f4787cb517efd3f5b8157eaefd6",
+                "sha256:e1c3c582ee11af7f63a34a46f0448fca58e59889396ffdae1f482085061a2889"
             ],
             "index": "pypi",
-            "version": "==3.4.4"
+            "version": "==3.5.4"
         },
         "async-timeout": {
             "hashes": [
@@ -86,13 +84,6 @@
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
             "version": "==2.8"
-        },
-        "idna-ssl": {
-            "hashes": [
-                "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"
-            ],
-            "markers": "python_version < '3.7'",
-            "version": "==1.1.0"
         },
         "kiwisolver": {
             "hashes": [
@@ -182,36 +173,31 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:0df89ca13c25eaa1621a3f09af4c8ba20da849692dcae184cb55e80952c453fb",
-                "sha256:154c35f195fd3e1fad2569930ca51907057ae35e03938f89a8aedae91dd1b7c7",
-                "sha256:18e84323cdb8de3325e741a7a8dd4a82db74fde363dce32b625324c7b32aa6d7",
-                "sha256:1e8956c37fc138d65ded2d96ab3949bd49038cc6e8a4494b1515b0ba88c91565",
-                "sha256:23557bdbca3ccbde3abaa12a6e82299bc92d2b9139011f8c16ca1bb8c75d1e95",
-                "sha256:24fd645a5e5d224aa6e39d93e4a722fafa9160154f296fd5ef9580191c755053",
-                "sha256:36e36b6868e4440760d4b9b44587ea1dc1f06532858d10abba98e851e154ca70",
-                "sha256:3d734559db35aa3697dadcea492a423118c5c55d176da2f3be9c98d4803fc2a7",
-                "sha256:416a2070acf3a2b5d586f9a6507bb97e33574df5bd7508ea970bbf4fc563fa52",
-                "sha256:4a22dc3f5221a644dfe4a63bf990052cc674ef12a157b1056969079985c92816",
-                "sha256:4d8d3e5aa6087490912c14a3c10fbdd380b40b421c13920ff468163bc50e016f",
-                "sha256:4f41fd159fba1245e1958a99d349df49c616b133636e0cf668f169bce2aeac2d",
-                "sha256:561ef098c50f91fbac2cc9305b68c915e9eb915a74d9038ecf8af274d748f76f",
-                "sha256:56994e14b386b5c0a9b875a76d22d707b315fa037affc7819cda08b6d0489756",
-                "sha256:73a1f2a529604c50c262179fcca59c87a05ff4614fe8a15c186934d84d09d9a5",
-                "sha256:7da99445fd890206bfcc7419f79871ba8e73d9d9e6b82fe09980bc5bb4efc35f",
-                "sha256:99d59e0bcadac4aa3280616591fb7bcd560e2218f5e31d5223a2e12a1425d495",
-                "sha256:a4cc09489843c70b22e8373ca3dfa52b3fab778b57cf81462f1203b0852e95e3",
-                "sha256:a61dc29cfca9831a03442a21d4b5fd77e3067beca4b5f81f1a89a04a71cf93fa",
-                "sha256:b1853df739b32fa913cc59ad9137caa9cc3d97ff871e2bbd89c2a2a1d4a69451",
-                "sha256:b1f44c335532c0581b77491b7715a871d0dd72e97487ac0f57337ccf3ab3469b",
-                "sha256:b261e0cb0d6faa8fd6863af26d30351fd2ffdb15b82e51e81e96b9e9e2e7ba16",
-                "sha256:c857ae5dba375ea26a6228f98c195fec0898a0fd91bcf0e8a0cae6d9faf3eca7",
-                "sha256:cf5bb4a7d53a71bb6a0144d31df784a973b36d8687d615ef6a7e9b1809917a9b",
-                "sha256:db9814ff0457b46f2e1d494c1efa4111ca089e08c8b983635ebffb9c1573361f",
-                "sha256:df04f4bad8a359daa2ff74f8108ea051670cafbca533bb2636c58b16e962989e",
-                "sha256:ecf81720934a0e18526177e645cbd6a8a21bb0ddc887ff9738de07a1df5c6b61",
-                "sha256:edfa6fba9157e0e3be0f40168eb142511012683ac3dc82420bee4a3f3981b30e"
+                "sha256:00a458d6821b1e87be873f2126d5646b901047a7480e8ae9773ecf214f0e19f3",
+                "sha256:0470c5dc32212a08ebc2405f32e8ceb9a5b1c8ac61a2daf9835ec0856a220495",
+                "sha256:24a9c287a4a1c427c2d45bf7c4fc6180c52a08fa0990d4c94e4c86a9b1e23ba5",
+                "sha256:25600e8901012180a1b7cd1ac3e27e7793586ecd432383191929ac2edf37ff5d",
+                "sha256:2d279bd99329e72c30937bdef82b6dc7779c7607c5a379bab1bf76be1f4c1422",
+                "sha256:32af2bcf4bb7631dac19736a6e092ec9715e770dcaa1f85fcd99dec5040b2a4d",
+                "sha256:3e90a9fce378114b6c2fc01fff7423300515c7b54b7cc71b02a22bc0bd7dfdd8",
+                "sha256:5774d49516c37fd3fc1f232e033d2b152f3323ca4c7bfefd7277e4c67f3c08b4",
+                "sha256:64ff21aac30d40c20ba994c94a08d439b8ced3b9c704af897e9e4ba09d10e62c",
+                "sha256:803b2af862dcad6c11231ea3cd1015d1293efd6c87088be33d713a9b23e9e419",
+                "sha256:95c830b09626508f7808ce7f1344fb98068e63143e6050e5dc3063142fc60007",
+                "sha256:96e49a0c82b4e3130093002f625545104037c2d25866fa2e0c90d6e54f5a1fbc",
+                "sha256:a1dd8221f0e69038748f47b8bb3248d0b9ecdf13fe837440951c3d5ff72639bb",
+                "sha256:a80ecac5664f420556a725a5646f2d1c60a7c0489d68a38b5056393e949e27ac",
+                "sha256:b19a47ff1bd2fca0cacdfa830c967746764c32dca6a0c0328d9c893f4bfe2f6b",
+                "sha256:be43df2c563e264b38e3318574d80fc8f365df3fb745270934d2dbe54e006f41",
+                "sha256:c40cb17188f6ae3c5b6efc6f0fd43a7ddd219b7807fe179e71027849a9b91afc",
+                "sha256:c6251e0f0ecac53ba2b99d9f0cc16fa9021914a78869c38213c436ba343641f0",
+                "sha256:cb189bd98b2e7ac02df389b6212846ab20661f4bafe16b5a70a6f1728c1cc7cb",
+                "sha256:ef4ae41add536cb825d8aa029c15ef510aead06ea5b68daea64f0b9ecbff17db",
+                "sha256:f00a2c21f60284e024bba351875f3501c6d5817d64997a0afe4f4355161a8889",
+                "sha256:f1232f98a6bbd6d1678249f94028bccc541bbc306aa5c4e1471a881b0e5a3409",
+                "sha256:fea682f6ddc09517df0e6d5caad9613c6d91a42232aeb082df67e4d205de19cc"
             ],
-            "version": "==1.15.4"
+            "version": "==1.16.0"
         },
         "pandas": {
             "hashes": [
@@ -241,10 +227,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:40856e74d4987de5d01761a22d1621ae1c7f8774585acae358aa5c5936c6c90b",
-                "sha256:f353aab21fd474459d97b709e527b5571314ee5f067441dc9f88e33eecd96592"
+                "sha256:66c9268862641abcac4a96ba74506e594c884e3f57690a696d21ad8210ed667a",
+                "sha256:f6c5ef0d7480ad048c054c37632c67fca55299990fff127850181659eea33fc3"
             ],
-            "version": "==2.3.0"
+            "version": "==2.3.1"
         },
         "python-dateutil": {
             "hashes": [
@@ -256,10 +242,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
-                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
+                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
+                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
             ],
-            "version": "==2018.7"
+            "version": "==2018.9"
         },
         "six": {
             "hashes": [

--- a/scripts/commit_count/Pipfile.lock
+++ b/scripts/commit_count/Pipfile.lock
@@ -1,0 +1,99 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "31bd621c969b5d9c5352c727b2a79d0a77af875e2050816d07a362f98c271254"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
+                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
+            ],
+            "version": "==2018.10.15"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "deprecated": {
+            "hashes": [
+                "sha256:0b1e043af3bab6c7ebcf96a471d0e75685ffe1390924e28137a8f1bd33781195",
+                "sha256:bcad09662cbf6f1a01fcb72474b9ab4bd35ee284b5f064bc31c4524d2f4cd82e"
+            ],
+            "version": "==1.2.3"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+            ],
+            "version": "==2.7"
+        },
+        "pygithub": {
+            "hashes": [
+                "sha256:af205fa50d5e18b880c567f77cffbafa23f69988ca8f8f869ad30c535bc7d36f"
+            ],
+            "index": "pypi",
+            "version": "==1.43.2"
+        },
+        "pyjwt": {
+            "hashes": [
+                "sha256:30b1380ff43b55441283cc2b2676b755cca45693ae3097325dea01f3d110628c",
+                "sha256:4ee413b357d53fd3fb44704577afac88e72e878716116270d722723d65b42176"
+            ],
+            "version": "==1.6.4"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
+                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
+            ],
+            "index": "pypi",
+            "version": "==2.7.5"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c",
+                "sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279"
+            ],
+            "version": "==2.20.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:41c3db2fc01e5b907288010dec72f9d0a74e37d6994e6eb56849f59fea2265ae",
+                "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
+            ],
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.1.*' and python_version < '4' and python_version != '3.0.*'",
+            "version": "==1.24"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:d4d560d479f2c21e1b5443bbd15fe7ec4b37fe7e53d335d3b9b0a7b1226fe3c6"
+            ],
+            "version": "==1.10.11"
+        }
+    },
+    "develop": {}
+}

--- a/scripts/commit_count/get_commit_count.py
+++ b/scripts/commit_count/get_commit_count.py
@@ -1,33 +1,55 @@
 import os
 import csv
+import asyncio
 from datetime import datetime, timedelta
 
+import aiohttp
+import aiofiles
 from dateutil import rrule
-from github import Github
-from github.PaginatedList import PaginatedList
-from github.Repository import Repository
 
 
+class RepoStat:
 
-def prompt_user() -> (str, str):
-    user = input('Enter user: ').strip()
+    __slots__ = ('date', 'commit_count')
 
-    password = input('Enter password: ').strip()
+    def __init__(self, date: datetime, commit_count: int):
+        self.date = date
 
-    return user, password
+        self.commit_count = commit_count
 
-
-def get_repos() -> PaginatedList:
-    user, password = prompt_user()
-
-    github_client = Github(user, password)
-
-    exercism_org = github_client.get_organization('Exercism')
-
-    return exercism_org.get_repos()
+    def into_tuple(self) -> tuple:
+        return (self.date.strftime('%d.%m.%Y'), self.commit_count)
 
 
-def get_repo_data(repo: Repository):
+class Repo:
+
+    __slots__ = ('name', 'commits_url', 'repo_stats')
+
+    def __init__(self, repo: dict):
+        self.name = repo['name']
+
+        self.commits_url = repo['commits_url'][:-6]
+
+        self.repo_stats = None
+
+
+async def get_repos() -> map:
+    params = {
+        'access_token': os.environ['GITHUB_TOKEN']
+    }
+
+    async with aiohttp.ClientSession() as session:
+        async with session.get(
+                'https://api.github.com/orgs/exercism/repos',
+                params=params) as response:
+            repos = await response.json()
+
+            return map(lambda repo: Repo(repo), repos)
+
+
+async def get_repo_stats(repo: Repo) -> Repo:
+    repo_stats = list()
+
     now = datetime.now()
 
     start_point = now - timedelta(days=31*6)
@@ -35,42 +57,115 @@ def get_repo_data(repo: Repository):
     for day in rrule.rrule(rrule.DAILY, dtstart=start_point, until=now):
         prev_day = day - timedelta(days=1)
 
-        commits = repo.get_commits(since=prev_day, until=day)
+        params = {
+            'since': prev_day.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            'until': day.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            'access_token': os.environ['GITHUB_TOKEN']
+        }
 
-        yield (day.strftime('%d.%m.%Y'), commits.totalCount)
+        async with aiohttp.ClientSession() as session:
+            async with session.get(repo.commits_url, params=params)\
+                    as response:
+                commits = await response.json()
+
+        repo_stat = RepoStat(day, len(commits))
+
+        repo_stats.append(repo_stat)
+
+    repo.repo_stats = repo_stats
+
+    return repo
 
 
-def generate_result(repo: Repository):
-    #FIXME: Relative paths are bad. Change this later
-    result_dir_path = '../../results/commits_count'
+async def write_result(repo: Repo):
+    result_dir_path = os.path.join(os.environ['RESULT_DIR'], repo.name)
 
     if not os.path.exists(result_dir_path):
         os.makedirs(result_dir_path)
 
-    result_path = os.path.join(
-        result_dir_path,
-        '{}.csv'.format(repo.name)
-    )
+    result_file_path = os.path.join(result_dir_path, 'commit_count.csv')
 
     fields = ['date', 'commit_count']
 
-    repo_data = get_repo_data(repo)
-
-    with open(result_path, 'w') as result_file:
+    async with aiofiles.open(result_file_path, 'w') as result_file:
         csv_writer = csv.writer(result_file)
 
-        csv_writer.writerow(fields)
+        await csv_writer.writerow(fields)
 
-        for data_line in repo_data:
-            csv_writer.writerow(data_line)
+        repo_stats = map(
+            lambda repo_stat: repo_stat.into_tuple(),
+            repo.repo_stats
+        )
+
+        for data_line in repo_stats:
+            await csv_writer.writerow(data_line)
 
 
-def count_commits():
-    repos = get_repos()
+async def count_commits():
+    repos = await get_repos()
 
-    for repo in repos:
-        generate_result(repo)
+    repo_stats_tasks = [get_repo_stats(repo) for repo in repos]
+
+    for stat_future in asyncio.as_completed(repo_stats_tasks):
+        repo = await stat_future
+
+        await write_result(repo)
+
+
+def main():
+    loop = None
+
+    try:
+        loop = asyncio.get_event_loop()
+
+        loop.run_until_complete(count_commits())
+
+        print('Done!')
+    except Exception as ex:
+        print(ex)
+    finally:
+        if loop:
+            loop.close()
+
+
+def check_envinroment_variables() -> (dict, dict):
+    required_variables = {
+        'RESULT_DIR': os.environ.get('RESULT_DIR'),
+        'GITHUB_TOKEN': os.environ.get('GITHUB_TOKEN'),
+    }
+
+    present_variables = dict()
+
+    missing_variables = dict()
+
+    for name, value in required_variables.items():
+        if not value:
+            missing_variables[name] = value
+        else:
+            present_variables[name] = value
+
+    return present_variables, missing_variables
 
 
 if __name__ == '__main__':
-    count_commits()
+    present_variables, missing_variables = check_envinroment_variables()
+
+    if missing_variables:
+        print(
+            (
+                'Some required environment variables were not set:\n{}\n\n'
+                'The script is aborted.'
+            ).format('\n'.join(missing_variables.keys()))
+        )
+    else:
+        print('The following environment variables were set:')
+
+        for k, v in present_variables.items():
+            print('{}: {}'.format(k, v))
+
+        result_dir_path = os.environ['RESULT_DIR']
+
+        if not os.path.exists(result_dir_path):
+            os.makedirs(result_dir_path)
+
+        main()

--- a/scripts/commit_count/get_commit_count.py
+++ b/scripts/commit_count/get_commit_count.py
@@ -68,7 +68,13 @@ async def get_repo_stats(repo: Repo) -> Repo:
                     as response:
                 commits = await response.json()
 
-        repo_stat = RepoStat(day, len(commits))
+        commit_count = len(commits) if \
+            commits and \
+            isinstance(commits, list) and \
+            'commit' in commits[0] \
+            else 0
+
+        repo_stat = RepoStat(day, commit_count)
 
         repo_stats.append(repo_stat)
 

--- a/scripts/commit_count/get_commit_count.py
+++ b/scripts/commit_count/get_commit_count.py
@@ -1,0 +1,76 @@
+import os
+import csv
+from datetime import datetime, timedelta
+
+from dateutil import rrule
+from github import Github
+from github.PaginatedList import PaginatedList
+from github.Repository import Repository
+
+
+
+def prompt_user() -> (str, str):
+    user = input('Enter user: ').strip()
+
+    password = input('Enter password: ').strip()
+
+    return user, password
+
+
+def get_repos() -> PaginatedList:
+    user, password = prompt_user()
+
+    github_client = Github(user, password)
+
+    exercism_org = github_client.get_organization('Exercism')
+
+    return exercism_org.get_repos()
+
+
+def get_repo_data(repo: Repository):
+    now = datetime.now()
+
+    start_point = now - timedelta(days=31*6)
+
+    for day in rrule.rrule(rrule.DAILY, dtstart=start_point, until=now):
+        prev_day = day - timedelta(days=1)
+
+        commits = repo.get_commits(since=prev_day, until=day)
+
+        yield (day.strftime('%d.%m.%Y'), commits.totalCount)
+
+
+def generate_result(repo: Repository):
+    #FIXME: Relative paths are bad. Change this later
+    result_dir_path = '../../results/commits_count'
+
+    if not os.path.exists(result_dir_path):
+        os.makedirs(result_dir_path)
+
+    result_path = os.path.join(
+        result_dir_path,
+        '{}.csv'.format(repo.name)
+    )
+
+    fields = ['date', 'commit_count']
+
+    repo_data = get_repo_data(repo)
+
+    with open(result_path, 'w') as result_file:
+        csv_writer = csv.writer(result_file)
+
+        csv_writer.writerow(fields)
+
+        for data_line in repo_data:
+            csv_writer.writerow(data_line)
+
+
+def count_commits():
+    repos = get_repos()
+
+    for repo in repos:
+        generate_result(repo)
+
+
+if __name__ == '__main__':
+    count_commits()

--- a/scripts/commit_count/get_commit_count.py
+++ b/scripts/commit_count/get_commit_count.py
@@ -15,7 +15,6 @@ class RepoStat:
 
     def __init__(self, date: datetime, commit_count: int):
         self.date = date
-
         self.commit_count = commit_count
 
     def into_tuple(self) -> tuple:
@@ -28,9 +27,7 @@ class Repo:
 
     def __init__(self, repo: dict):
         self.name = repo['name']
-
         self.commits_url = repo['commits_url'][:-6]
-
         self.repo_stats = None
 
 
@@ -74,17 +71,13 @@ async def get_repo_stats(repo: Repo) -> Repo:
             break
 
         day_count = defaultdict(lambda: 0)
-
         minimal_date = commit_to_date(commits[0])
-
         for commit in commits:
             commit_date = commit_to_date(commit)
-
             if commit_date < minimal_date:
                 minimal_date = commit_date
 
             day_key = commit_date.strftime('%Y-%m-%d')
-
             day_count[day_key] += 1
 
         if minimal_date == until:
@@ -94,50 +87,41 @@ async def get_repo_stats(repo: Repo) -> Repo:
 
         for day in rrule.rrule(rrule.DAILY, dtstart=minimal_date, until=until):
             repo_stat = RepoStat(day, day_count[day.strftime('%Y-%m-%d')])
-
             interval_stats.append(repo_stat)
 
         repo_stats.extend(reversed(interval_stats))
-
         until = minimal_date
 
     repo.repo_stats = repo_stats
-
     return repo
 
 
 async def write_result(repo: Repo):
     result_dir_path = os.path.join(os.environ['RESULT_DIR'], repo.name)
-
     if not os.path.exists(result_dir_path):
         os.makedirs(result_dir_path)
 
     result_file_path = os.path.join(result_dir_path, 'commit_count.csv')
-
     fields = ['date', 'commit_count']
 
     async with aiofiles.open(result_file_path, 'w') as result_file:
         csv_writer = csv.writer(result_file)
-
         await csv_writer.writerow(fields)
 
         repo_stats = map(
             lambda repo_stat: repo_stat.into_tuple(),
             repo.repo_stats
         )
-
         for data_line in repo_stats:
             await csv_writer.writerow(data_line)
 
 
 async def count_commits():
     repos = await get_repos()
-
     repo_stats_tasks = [get_repo_stats(repo) for repo in repos]
 
     for stat_future in asyncio.as_completed(repo_stats_tasks):
         repo = await stat_future
-
         await write_result(repo)
 
 
@@ -146,9 +130,7 @@ def main():
 
     try:
         loop = asyncio.get_event_loop()
-
         loop.run_until_complete(count_commits())
-
         print('Done!')
     except Exception as ex:
         print(ex)
@@ -162,11 +144,8 @@ def check_envinroment_variables() -> (dict, dict):
         'RESULT_DIR': os.environ.get('RESULT_DIR'),
         'GITHUB_TOKEN': os.environ.get('GITHUB_TOKEN'),
     }
-
     present_variables = dict()
-
     missing_variables = dict()
-
     for name, value in required_variables.items():
         if not value:
             missing_variables[name] = value
@@ -187,12 +166,10 @@ if __name__ == '__main__':
         )
     else:
         print('The following environment variables were set:')
-
         for k, v in present_variables.items():
             print('{}: {}'.format(k, v))
 
         result_dir_path = os.environ['RESULT_DIR']
-
         if not os.path.exists(result_dir_path):
             os.makedirs(result_dir_path)
 

--- a/scripts/commit_count/plot_commit_count.py
+++ b/scripts/commit_count/plot_commit_count.py
@@ -13,10 +13,8 @@ import pandas as pd
 
 def generate_plot(result_dir: str):
     commit_count_file = os.path.join(result_dir, 'commit_count.csv')
-
     if not os.path.exists(commit_count_file):
         print('Commit count CSV file not found for the {}'.format(result_dir))
-
         return
 
     commit_count_content = pd.read_csv(
@@ -29,17 +27,11 @@ def generate_plot(result_dir: str):
     x_pos = range(len(commit_count_content))
 
     plt.bar(x_pos, commit_count_content['commit_count'])
-
     plt.xticks(x_pos, commit_count_content['date'], rotation=90)
-
     plt.ylabel('Commit Count')
-
     plt.xlabel('Date')
-
     plt.title(os.path.split(result_dir)[-1])
-
     plt.savefig(os.path.join(result_dir, 'commit_count.png'))
-
     plt.close()
 
 
@@ -51,7 +43,6 @@ def main():
 
     for dir in result_dirs:
         print('Plotting', dir)
-
         generate_plot(dir)
 
 
@@ -59,9 +50,7 @@ def check_envinroment_variables() -> (dict, dict):
     required_variables = {
         'RESULT_DIR': os.environ.get('RESULT_DIR'),
     }
-
     present_variables = dict()
-
     missing_variables = dict()
 
     for name, value in required_variables.items():
@@ -85,7 +74,6 @@ if __name__ == '__main__':
         )
     else:
         print('The following environment variables were set:')
-
         for k, v in present_variables.items():
             print('{}: {}'.format(k, v))
 

--- a/scripts/commit_count/plot_commit_count.py
+++ b/scripts/commit_count/plot_commit_count.py
@@ -3,6 +3,11 @@ import os
 import matplotlib
 matplotlib.use('agg')
 import matplotlib.pyplot as plt
+plt.rcParams["figure.figsize"] = [120, 8]
+plt.rcParams["figure.dpi"] = 200
+plt.rcParams["font.size"] = 3
+
+
 import pandas as pd
 
 
@@ -27,19 +32,11 @@ def generate_plot(result_dir: str):
 
     plt.xticks(x_pos, commit_count_content['date'], rotation=90)
 
- #   plt.plot(commit_count_content['date'], commit_count_content['commit_count'])
-
     plt.ylabel('Commit Count')
 
     plt.xlabel('Date')
 
- #   plt.xticks(rotation=90)
-
     plt.title(os.path.split(result_dir)[-1])
-
-    plt.rcParams["figure.figsize"] = [60, 20]
-
-    # plt.show()
 
     plt.savefig(os.path.join(result_dir, 'commit_count.png'))
 
@@ -53,13 +50,14 @@ def main():
     )
 
     for dir in result_dirs:
+        print('Plotting', dir)
+
         generate_plot(dir)
 
 
 def check_envinroment_variables() -> (dict, dict):
     required_variables = {
         'RESULT_DIR': os.environ.get('RESULT_DIR'),
-        'GITHUB_TOKEN': os.environ.get('GITHUB_TOKEN'),
     }
 
     present_variables = dict()

--- a/scripts/commit_count/plot_commit_count.py
+++ b/scripts/commit_count/plot_commit_count.py
@@ -1,5 +1,10 @@
 import os
 
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+import pandas as pd
+
 
 def generate_plot(result_dir: str):
     commit_count_file = os.path.join(result_dir, 'commit_count.csv')
@@ -9,6 +14,37 @@ def generate_plot(result_dir: str):
 
         return
 
+    commit_count_content = pd.read_csv(
+        commit_count_file,
+        sep=',',
+        header=0,
+        names=['date', 'commit_count']
+    )
+
+    x_pos = range(len(commit_count_content))
+
+    plt.bar(x_pos, commit_count_content['commit_count'])
+
+    plt.xticks(x_pos, commit_count_content['date'], rotation=90)
+
+ #   plt.plot(commit_count_content['date'], commit_count_content['commit_count'])
+
+    plt.ylabel('Commit Count')
+
+    plt.xlabel('Date')
+
+ #   plt.xticks(rotation=90)
+
+    plt.title(os.path.split(result_dir)[-1])
+
+    plt.rcParams["figure.figsize"] = [60, 20]
+
+    # plt.show()
+
+    plt.savefig(os.path.join(result_dir, 'commit_count.png'))
+
+    plt.close()
+
 
 def main():
     result_dirs = map(
@@ -17,11 +53,7 @@ def main():
     )
 
     for dir in result_dirs:
-        print(dir)
-
         generate_plot(dir)
-
-        break
 
 
 def check_envinroment_variables() -> (dict, dict):

--- a/scripts/commit_count/plot_commit_count.py
+++ b/scripts/commit_count/plot_commit_count.py
@@ -1,0 +1,70 @@
+import os
+
+
+def generate_plot(result_dir: str):
+    commit_count_file = os.path.join(result_dir, 'commit_count.csv')
+
+    if not os.path.exists(commit_count_file):
+        print('Commit count CSV file not found for the {}'.format(result_dir))
+
+        return
+
+
+def main():
+    result_dirs = map(
+        lambda dir_name: os.path.join(os.environ['RESULT_DIR'], dir_name),
+        os.listdir(os.environ['RESULT_DIR'])
+    )
+
+    for dir in result_dirs:
+        print(dir)
+
+        generate_plot(dir)
+
+        break
+
+
+def check_envinroment_variables() -> (dict, dict):
+    required_variables = {
+        'RESULT_DIR': os.environ.get('RESULT_DIR'),
+        'GITHUB_TOKEN': os.environ.get('GITHUB_TOKEN'),
+    }
+
+    present_variables = dict()
+
+    missing_variables = dict()
+
+    for name, value in required_variables.items():
+        if not value:
+            missing_variables[name] = value
+        else:
+            present_variables[name] = value
+
+    return present_variables, missing_variables
+
+
+if __name__ == '__main__':
+    present_variables, missing_variables = check_envinroment_variables()
+
+    if missing_variables:
+        print(
+            (
+                'Some required environment variables were not set:\n{}\n\n'
+                'The script is aborted.'
+            ).format('\n'.join(missing_variables.keys()))
+        )
+    else:
+        print('The following environment variables were set:')
+
+        for k, v in present_variables.items():
+            print('{}: {}'.format(k, v))
+
+        result_dir_path = os.environ['RESULT_DIR']
+
+        if os.path.exists(result_dir_path):
+            main()
+        else:
+            print((
+                'Result directory does not exist.'
+                ' Run get_commit_count.py script to generate it.'
+            ))


### PR DESCRIPTION
A first version of a Python script for the #1.

For now it generates the csv files for the existing Exercism repos with the `date,commit_count` format in the `results/commits_count` directory.

It depends on some external libraries (namely `PyGithub` and `python-dateutils`) so I have used `pipenv` for the development of a script.

The easiest way to run the script is to use the `pipenv run python get_commit_count.py` command from the script directory

Opened as `In Progress` since there are some rough parts of the script, which I could not solve, because I am not familiar with the environment in which the script will be launched:
- The relative path to the `results` directory. Perhaps `.env` file could be used here?
- The authorization at the start of the script (otherwise Github API would not permit many requests) via command line prompt
- No pull requests data (could not find a request in Github API that takes `from`/`until` dates)
- It is simply slow. Perhaps could be solved with multi-threading or `asyncio`. 
